### PR TITLE
[FIXED JENKINS-25660] - Use hudson.Util methods to tokenize axis values

### DIFF
--- a/src/main/java/ca/silvermaplesolutions/jenkins/plugins/daxis/DynamicAxis.java
+++ b/src/main/java/ca/silvermaplesolutions/jenkins/plugins/daxis/DynamicAxis.java
@@ -22,6 +22,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import com.google.common.collect.Lists;
+import hudson.Util;
 
 /**
  * Implements dynamic axis support through a configurable environment variable.
@@ -115,7 +116,7 @@ public class DynamicAxis extends Axis
 					if( varValue != null )
 					{
 						LOGGER.fine( "Variable value is '" + varValue + "'" );
-						for( String item : varValue.split( " " ) )
+						for( String item : Util.tokenize(varValue) )
 						{
 							axisValues.add( item );
 						}


### PR DESCRIPTION
This method follows the approach in Matrix Project plugin.
In particular, the quoted values won't be splitted to several axis values.

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
