### PR TITLE
[JENKINS-27243] - Fix the improper Axis values initialization on buildEnvironment() with circular dependencies

### DIFF
--- a/src/main/java/ca/silvermaplesolutions/jenkins/plugins/daxis/DynamicAxis.java
+++ b/src/main/java/ca/silvermaplesolutions/jenkins/plugins/daxis/DynamicAxis.java
@@ -24,6 +24,8 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import com.google.common.collect.Lists;
 import hudson.Util;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * Implements dynamic axis support through a configurable environment variable.
@@ -34,8 +36,8 @@ public class DynamicAxis extends Axis
 {
 	private static final Logger LOGGER = Logger.getLogger( DynamicAxis.class.getName() );
 
-	private String varName = "";
-	private List<String> axisValues = Lists.newArrayList();
+	private @CheckForNull String varName = "";
+	private final @Nonnull List<String> axisValues = Lists.newArrayList();
 
 	/**
 	 * Always construct from an axis name and environment variable name.
@@ -51,9 +53,10 @@ public class DynamicAxis extends Axis
 
 	/**
 	 * An accessor is required if referenced in the Jelly file.
-	 * @return the name of the variable
+	 * @return Name of the variable. Null values will be replaced 
+         * by empty strings.
 	 */
-	public synchronized String getVarName()
+	public synchronized @Nonnull String getVarName()
 	{
 		return varName == null ? "" : varName;
 	}
@@ -74,9 +77,11 @@ public class DynamicAxis extends Axis
 	 * Overridden to provide a default value in the event the target environment
 	 * variable cannot be accessed or interpreted.
 	 * @see hudson.matrix.Axis#getValues()
+         * @return Cached list of axis values from the last 
+         * {@link #rebuild(hudson.matrix.MatrixBuild.MatrixBuildExecution)} call
 	 */
 	@Override
-	public synchronized List<String> getValues()
+	public synchronized @Nonnull List<String> getValues()
 	{
 		checkForDefaultValues();
 		return axisValues;
@@ -85,9 +90,11 @@ public class DynamicAxis extends Axis
 	/**
 	 * Overridden to return our environment variable name.
 	 * @see hudson.matrix.Axis#getValueString()
+         * @return Name of the variable. Null values will be replaced 
+         * by empty strings.
 	 */
 	@Override
-	public synchronized String getValueString()
+	public synchronized @Nonnull String getValueString()
 	{
 		return getVarName();
 	}
@@ -99,7 +106,7 @@ public class DynamicAxis extends Axis
 	 * @see hudson.matrix.Axis#rebuild(hudson.matrix.MatrixBuild.MatrixBuildExecution)
 	 */
 	@Override
-	public synchronized List<String> rebuild( MatrixBuild.MatrixBuildExecution context )
+	public synchronized @Nonnull List<String> rebuild( MatrixBuild.MatrixBuildExecution context )
 	{
 		// clear any existing values to ensure we do not return old ones
 		LOGGER.fine( "Rebuilding axis names from variable '" + varName + "'" );

--- a/src/test/java/ca/silvermaplesolutions/jenkins/plugins/daxis/DynamicAxisTest.java
+++ b/src/test/java/ca/silvermaplesolutions/jenkins/plugins/daxis/DynamicAxisTest.java
@@ -1,0 +1,73 @@
+package ca.silvermaplesolutions.jenkins.plugins.daxis;
+
+import hudson.matrix.Axis;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
+import hudson.model.AbstractBuild;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
+import java.util.Map;
+import org.junit.Test;
+import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.FakeChangeLogSCM;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+/**
+ * Tests for {@link DynamicAxis}.
+ * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ */
+public class DynamicAxisTest extends HudsonTestCase {
+    
+    MatrixProject p;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp(); 
+        p = createMatrixProject();
+        p.getAxes().add(new DynamicAxis("AXIS", "AXIS_VALUES"));     
+    }
+    
+    public @Test void testDefaultInjection() throws Exception {
+        p.addProperty(new ParametersDefinitionProperty(
+                new StringParameterDefinition("AXIS_VALUES", "1 2 3")));
+        
+        MatrixBuild run = buildAndAssertSuccess(p);
+        assertEquals(3, run.getExactRuns().size());
+    }
+    
+    /**
+     * Runs the test, when an environment contributor uses axis values
+     * to build the environment.
+     * @see AxisValuesUserSCM
+     */
+    @Bug(27243) 
+    public @Test void testInjectionWithAxisValuesUser() throws Exception {
+        p.addProperty(new ParametersDefinitionProperty(
+                new StringParameterDefinition("AXIS_VALUES", "1 2 3")));
+        
+        // Inject SCM, which implicitly triggers axes rebuild
+        p.setScm(new AxisValuesUserSCM());
+        
+        final MatrixBuild run = buildAndAssertSuccess(p);
+        
+        // No additional values have been injected
+        assertEquals(3, run.getExactRuns().size());
+    }
+    
+    /**
+     * Just a stub {@link SCM}, which rebuilds axes list. 
+     */
+    public static class AxisValuesUserSCM extends FakeChangeLogSCM {
+        
+        @Override
+        public void buildEnvVars(AbstractBuild<?, ?> build, Map<String, String> env) {
+            if (build instanceof MatrixBuild) {
+                final MatrixProject prj = (MatrixProject) build.getParent();
+                for (Axis axis : prj.getAxes()) {
+                    // Get values for a opeeration
+                    axis.getValues();
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/ca/silvermaplesolutions/jenkins/plugins/daxis/DynamicAxisTest.java
+++ b/src/test/java/ca/silvermaplesolutions/jenkins/plugins/daxis/DynamicAxisTest.java
@@ -6,7 +6,9 @@ import hudson.matrix.MatrixProject;
 import hudson.model.AbstractBuild;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
+import java.util.Collection;
 import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.FakeChangeLogSCM;
@@ -34,6 +36,11 @@ public class DynamicAxisTest extends HudsonTestCase {
         MatrixBuild run = buildAndAssertSuccess(p);
         assertEquals(3, run.getExactRuns().size());
     }
+   
+    @Bug(25660)
+    public @Test void testInjectionWithEscaping() throws Exception {
+        checkAxesSetup(new String[]{"1", "\"2 3\""});
+    }
     
     /**
      * Runs the test, when an environment contributor uses axis values
@@ -42,8 +49,17 @@ public class DynamicAxisTest extends HudsonTestCase {
      */
     @Bug(27243) 
     public @Test void testInjectionWithAxisValuesUser() throws Exception {
+        checkAxesSetup(new String[]{"1", "2", "3"});
+    }
+    
+    /**
+     * Sets values from the list and then checks injection results.
+     * @param values List of values, which should be escaped externally
+     */
+    private void checkAxesSetup(String[] values) throws Exception  {
+        final String valuesString = StringUtils.join(values, " ");         
         p.addProperty(new ParametersDefinitionProperty(
-                new StringParameterDefinition("AXIS_VALUES", "1 2 3")));
+                new StringParameterDefinition("AXIS_VALUES", valuesString)));      
         
         // Inject SCM, which implicitly triggers axes rebuild
         p.setScm(new AxisValuesUserSCM());
@@ -51,7 +67,7 @@ public class DynamicAxisTest extends HudsonTestCase {
         final MatrixBuild run = buildAndAssertSuccess(p);
         
         // No additional values have been injected
-        assertEquals(3, run.getExactRuns().size());
+        assertEquals(values.length, run.getExactRuns().size());
     }
     
     /**


### PR DESCRIPTION
The bug may easily appear in Perforce Plugin, others may be affected as well